### PR TITLE
Stop looping on self-referencing contracts

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint:fix": "pnpm lint -- --fix",
     "prepare-deploy": "cp ./vercel.json ./packages/vscode-host/dist",
     "test": "mocha",
-    "check": "echo a"
+    "check": "pnpm test && pnpm lint"
   },
   "devDependencies": {
     "@types/jsdom": "^16.2.14",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint --ext .ts ./packages/*/src/**/*.ts",
     "lint:fix": "pnpm lint -- --fix",
     "prepare-deploy": "cp ./vercel.json ./packages/vscode-host/dist",
-    "test": "mocha"
+    "test": "mocha",
+    "check": "echo a"
   },
   "devDependencies": {
     "@types/jsdom": "^16.2.14",

--- a/packages/ethereum-viewer/src/addresses.ts
+++ b/packages/ethereum-viewer/src/addresses.ts
@@ -1,4 +1,6 @@
 export const addresses = {
   L1ChugSplashProxy: "0x99c9fc46f92e8a1c0dec1b1747d010903e884be1",
   DAI: "0x6b175474e89094c44da98b954eedeac495271d0f",
+  NonfungiblePositionManager: "0xc36442b4a4522e871399cd717abdd847ab11fe88",
+  UniswapV3Router: "0xe592427a0aece92de3edee1f18e0157c05861564",
 };

--- a/packages/ethereum-viewer/src/extension.ts
+++ b/packages/ethereum-viewer/src/extension.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import { addresses } from "./addresses";
 
 import { registerContributedCommands } from "./contributedCommands";
 import { executeHostCommand } from "./executeHostCommand";

--- a/packages/ethereum-viewer/src/extension.ts
+++ b/packages/ethereum-viewer/src/extension.ts
@@ -34,7 +34,7 @@ async function main(context: vscode.ExtensionContext) {
     name: network,
   });
 
-  let address: string | null = null;
+  let address: string | undefined;
 
   if (IN_DETH_HOST) address = await executeHostCommand("getContractAddress");
 
@@ -49,7 +49,7 @@ async function detectExplorerApiName(): Promise<explorer.ApiName> {
   if (IN_DETH_HOST) {
     const detectedName = await executeHostCommand("getApiName");
 
-    if (detectedName === null) return "etherscan";
+    if (!detectedName) return "etherscan";
 
     if (!(detectedName in explorerApiUrls)) {
       await vscode.window.showErrorMessage(

--- a/packages/vscode-host/src/deth/commands/ethViewerCommands.ts
+++ b/packages/vscode-host/src/deth/commands/ethViewerCommands.ts
@@ -1,7 +1,7 @@
 export const ethViewerCommands = {
   getBrowserUrl: () => window.location.href,
   replaceBrowserUrl: (url: string) => window.location.replace(url),
-  getContractAddress: (): string | null => {
+  getContractAddress: (): string | undefined => {
     const url = new URL(window.location.href);
 
     // surge.sh doesn't seem to support rewrites, so we also read from search params.
@@ -14,14 +14,16 @@ export const ethViewerCommands = {
     if (path.startsWith("token/")) path = path.slice(6);
     if (path.endsWith("/")) path = path.slice(0, -1);
 
-    return path.startsWith("0x") ? path : null;
+    return path.startsWith("0x") ? path : undefined;
   },
-  getApiName: (): string | null => {
+  getApiName: (): string | undefined => {
     const { hostname } = window.location;
 
     if (hostname.endsWith(".deth.net")) return hostname.slice(0, -9);
 
-    return new URLSearchParams(window.location.search).get("explorer");
+    return (
+      new URLSearchParams(window.location.search).get("explorer") || undefined
+    );
   },
   openRepoOnGithub: () => {
     window.open("https://github.com/dethcrypto/ethereum-code-viewer", "_blank");


### PR DESCRIPTION
Closes #14.

So, we didn't assume that a contract can have its own address in `.Implementation` response from Etherscan.