### PR TITLE
Finish tests for TextSearchProvider and return limitHit properly

### DIFF
--- a/packages/ethereum-viewer/src/explorer/fetchFiles.test.ts
+++ b/packages/ethereum-viewer/src/explorer/fetchFiles.test.ts
@@ -1,8 +1,8 @@
 import { assert } from "ts-essentials";
 
-import { fetchFiles } from "../explorer";
-import { ContractSourceResponse } from "../explorer/api-types";
 import type { fetch } from "../util/fetch";
+import { ContractSourceResponse } from "./api-types";
+import { fetchFiles } from "./fetchFiles";
 
 describe(fetchFiles.name, () => {
   it("calls optimistic.etherscan", async () => {

--- a/packages/ethereum-viewer/src/fs/textSearchProvider.test.ts
+++ b/packages/ethereum-viewer/src/fs/textSearchProvider.test.ts
@@ -4,6 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from "assert";
+import {
+  CancellationTokenSource,
+  Progress,
+  Range,
+  TextSearchOptions,
+  TextSearchResult,
+  Uri,
+} from "vscode";
 
 import {
   fixNewline,
@@ -15,34 +23,217 @@ describe(MemFSTextSearchProvider.name, () => {
   // @todo tests for fixRegexNewline
   // @todo tests for TextSearchProvider
 
-  it("fixNewline - matching", () => {
-    function testFixNewline([inputReg, testStr, shouldMatch = true]: readonly [
-      string,
-      string,
-      boolean?
-    ]): void {
-      const fixed = fixNewline(inputReg);
-      const reg = new RegExp(fixed);
-      assert.strictEqual(
-        reg.test(testStr),
-        shouldMatch,
-        `${inputReg} => ${reg}, ${testStr}, ${shouldMatch}`
-      );
-    }
+  const textSearchOptions: TextSearchOptions = {
+    maxResults: 10,
+    excludes: [],
+    includes: [],
+    folder: Uri.parse("memfs:///"),
+    useIgnoreFiles: false,
+    followSymlinks: true,
+    useGlobalIgnoreFiles: true,
+  };
 
-    (
+  it("provides expected search results", async () => {
+    const files: ConstructorParameters<typeof MemFSTextSearchProvider>[0] = [
       [
-        ["foo", "foo"],
+        "a.txt",
+        `\
+line one
+line two
+line three
+`,
+      ],
+      [
+        "b.txt",
+        `\
+first line in the second file
+there are two lines in this file
+`,
+      ],
+    ];
 
-        ["foo\n", "foo\r\n"],
-        ["foo\n", "foo\n"],
-        ["foo\nabc", "foo\r\nabc"],
-        ["foo\nabc", "foo\nabc"],
-        ["foo\r\n", "foo\r\n"],
+    let { progress, actual, provider } = setupProvider(files);
 
-        ["foo\nbarc", "foobar", false],
-        ["foobar", "foo\nbar", false],
-      ] as const
-    ).forEach(testFixNewline);
+    let searchComplete = provider.provideTextSearchResults(
+      { pattern: "one" },
+      textSearchOptions,
+      progress,
+      new CancellationTokenSource().token
+    );
+
+    let expected: TextSearchResult[] = [
+      {
+        uri: Uri.parse("memfs:///a.txt"),
+        ranges: [new Range(0, 5, 0, 8)],
+        preview: {
+          text: "line one",
+          matches: [new Range(0, 5, 0, 8)],
+        },
+      },
+    ];
+
+    // we actually don't need strict-equal here, we'd be fine with same elements in different order
+    assert.deepStrictEqual(await searchComplete, { limitHit: false });
+    assert.deepStrictEqual(actual, expected);
+
+    ({ progress, actual, provider } = setupProvider(files));
+
+    searchComplete = provider.provideTextSearchResults(
+      { pattern: "line" },
+      textSearchOptions,
+      progress,
+      new CancellationTokenSource().token
+    );
+
+    expected = [
+      {
+        uri: Uri.parse("memfs:///a.txt"),
+        ranges: [new Range(0, 0, 0, 4)],
+        preview: {
+          text: "line one",
+          matches: [new Range(0, 0, 0, 4)],
+        },
+      },
+      {
+        uri: Uri.parse("memfs:///a.txt"),
+        ranges: [new Range(1, 0, 1, 4)],
+        preview: {
+          text: "line two",
+          matches: [new Range(0, 0, 0, 4)],
+        },
+      },
+      {
+        uri: Uri.parse("memfs:///a.txt"),
+        ranges: [new Range(2, 0, 2, 4)],
+        preview: {
+          text: "line three",
+          matches: [new Range(0, 0, 0, 4)],
+        },
+      },
+      {
+        uri: Uri.parse("memfs:///b.txt"),
+        ranges: [new Range(0, 6, 0, 10)],
+        preview: {
+          text: "first line in the second file",
+          matches: [new Range(0, 6, 0, 10)],
+        },
+      },
+      {
+        uri: Uri.parse("memfs:///b.txt"),
+        ranges: [new Range(1, 14, 1, 18)],
+        preview: {
+          text: "there are two lines in this file",
+          matches: [new Range(0, 14, 0, 18)],
+        },
+      },
+    ];
+
+    assert.deepStrictEqual(await searchComplete, { limitHit: false });
+    assert.deepStrictEqual(actual, expected);
+  });
+
+  it("returns `limitHit: true` if results exceed `maxResults` given RegExp pattern", async () => {
+    const str = "1 2 3 4";
+    const { progress, actual, provider } = setupProvider([["a.txt", str]]);
+
+    const searchComplete = provider.provideTextSearchResults(
+      { pattern: "\\d", isRegExp: true },
+      { ...textSearchOptions, maxResults: 2 },
+      progress,
+      new CancellationTokenSource().token
+    );
+
+    assert.deepStrictEqual(await searchComplete, { limitHit: true });
+    assert.deepStrictEqual(actual, [
+      {
+        uri: Uri.parse("memfs:///a.txt"),
+        ranges: [new Range(0, 0, 0, 1), new Range(0, 2, 0, 3)],
+        preview: {
+          text: str,
+          matches: [new Range(0, 0, 0, 1), new Range(0, 2, 0, 3)],
+        },
+      },
+    ]);
+  });
+
+  it("returns `limitHit: true` if results exceed `maxResults` given string pattern", async () => {
+    const str = "\n0 0 0 0";
+    const { progress, actual, provider } = setupProvider([["a.txt", str]]);
+
+    const searchComplete = provider.provideTextSearchResults(
+      { pattern: "0" },
+      { ...textSearchOptions, maxResults: 3 },
+      progress,
+      new CancellationTokenSource().token
+    );
+
+    assert.deepStrictEqual(await searchComplete, { limitHit: true });
+    const ranges = stringifyResults(actual);
+    assert.deepStrictEqual(ranges, [
+      "/a.txt 1,0-1,1",
+      "/a.txt 1,2-1,3",
+      "/a.txt 1,4-1,5",
+    ]);
+  });
+
+  describe(fixNewline.name, () => {
+    it("adds optional \\r before \\n in pattern", () => {
+      function testFixNewline([
+        inputReg,
+        testStr,
+        shouldMatch = true,
+      ]: readonly [string, string, boolean?]): void {
+        const fixed = fixNewline(inputReg);
+        const reg = new RegExp(fixed);
+        assert.strictEqual(
+          reg.test(testStr),
+          shouldMatch,
+          `${inputReg} => ${reg}, ${testStr}, ${shouldMatch}`
+        );
+      }
+
+      (
+        [
+          ["foo", "foo"],
+
+          ["foo\n", "foo\r\n"],
+          ["foo\n", "foo\n"],
+          ["foo\nabc", "foo\r\nabc"],
+          ["foo\nabc", "foo\nabc"],
+          ["foo\r\n", "foo\r\n"],
+
+          ["foo\nbarc", "foobar", false],
+          ["foobar", "foo\nbar", false],
+        ] as const
+      ).forEach(testFixNewline);
+    });
   });
 });
+
+function setupProvider(
+  ...args: ConstructorParameters<typeof MemFSTextSearchProvider>
+) {
+  let actual: TextSearchResult[] = [];
+  const progress: Progress<TextSearchResult> = {
+    report: (result) => {
+      actual.push(result);
+    },
+  };
+
+  const provider = new MemFSTextSearchProvider(...args);
+
+  return { progress, actual, provider };
+}
+
+function stringifyResults(actual: TextSearchResult[]) {
+  return actual.flatMap((r) =>
+    "ranges" in r
+      ? (Array.isArray(r.ranges) ? r.ranges : [r.ranges]).map(
+          (range) => `${r.uri.path} ${stringifyRange(range)}`
+        )
+      : []
+  );
+}
+
+const stringifyRange = (range: Range) =>
+  `${range.start.line},${range.start.character}-${range.end.line},${range.end.character}`;

--- a/packages/ethereum-viewer/src/test/run-tests.ts
+++ b/packages/ethereum-viewer/src/test/run-tests.ts
@@ -6,12 +6,14 @@ export function run(): Promise<void> {
     mocha.setup({
       ui: "bdd",
       reporter: undefined,
+      color: true,
     });
 
     // bundles all files in the current directory matching `*.test`
     const importAll = (r: __WebpackModuleApi.RequireContext) =>
       r.keys().forEach(r);
-    importAll(require.context(".", true, /\.test$/));
+
+    importAll(require.context("..", true, /\.test$/));
 
     try {
       // Run the mocha test


### PR DESCRIPTION
Tests I promised. As a bonus bugfix, we now currently get all results from single line when pattern is a string instead of getting just the first one.