### PR TITLE
Change rootDir script runner in the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ cd packages/vscode-host/
 yarn
 cd ../../
 
-yarn build # this builds whole vscode and can take A LOT of time
-yarn serve
+pnpm build # this builds whole vscode and can take A LOT of time
+pnpm serve
 ```
 
 ### Scripts


### PR DESCRIPTION
Firstly, this actually worked, but "yarn check" won’t.

I’ll admit I’m using Yarn and PNPM as script runners interchangeably —  old habits die hard. However, the root package is managed by PNPM, and it contains one script "check" that collides with "yarn check" built-in name.