### PR TITLE
Add bookmarklet to the readme

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -3,5 +3,8 @@ module.exports = {
   extension: ["ts"],
   watchExtensions: ["ts"],
   // Extension tests run inside of VSCode instance, so we don't include them here
-  spec: ["packages/vscode-host/src/**/*.test.ts"],
+  spec: [
+    "packages/vscode-host/src/**/*.test.ts",
+    "packages/bookmarklet/*.test.ts",
+  ],
 };

--- a/README.md
+++ b/README.md
@@ -20,11 +20,19 @@ While browsing smart contract code on [Etherscan](https://etherscan.io/) just ch
 
 ![ecv](https://user-images.githubusercontent.com/1814312/146108385-6fa50ae7-14a5-45b2-be3d-201d22409cf7.gif)
 
+Or save the following code snippet as a bookmarklet to quickly go from any [supported chain explorer][supported_explorers] to Ethereum Code Viewer.
+
+```
+javascript: location.href = location.href.replace(/\.\w+(\/)/, ".deth.net/")
+```
+
 ## Features ⚡
 
 - frictionless - just tweak URL while browsing etherscan `.io` -> `deth.net`
 - proxy support - automatically follows proxies and displays implementation source code
-- multichain - supports different etherscan instances: testnets, L2s, L1s ([all supported chains](https://github.com/dethcrypto/ethereum-code-viewer/blob/main/packages/ethereum-viewer/src/explorer/networks.ts))
+- multichain - supports different etherscan instances: testnets, L2s, L1s ([all supported chains][supported_explorers])
+
+[supported_explorers]: https://github.com/dethcrypto/ethereum-code-viewer/blob/main/docs/supported-explorers.md
 
 ## Motivation
 

--- a/docs/supported-explorers.md
+++ b/docs/supported-explorers.md
@@ -1,0 +1,23 @@
+Ethereum Code Viewer supports the following blockchain explorers:
+
+<!-- Run `yarn supported-explorers` in packages/ethereum-viewer to generate this list. -->
+
+- [etherscan.io](https://etherscan.io)
+- [ropsten.etherscan.io](https://ropsten.etherscan.io)
+- [rinkeby.etherscan.io](https://rinkeby.etherscan.io)
+- [goerli.etherscan.io](https://goerli.etherscan.io)
+- [kovan.etherscan.io](https://kovan.etherscan.io)
+- [bscscan.com](https://bscscan.com)
+- [testnet.bscscan.com](https://testnet.bscscan.com)
+- [hecoinfo.com](https://hecoinfo.com)
+- [testnet.hecoinfo.com](https://testnet.hecoinfo.com)
+- [ftmscan.com](https://ftmscan.com)
+- [testnet.ftmscan.com](https://testnet.ftmscan.com)
+- [optimistic.etherscan.io](https://optimistic.etherscan.io)
+- [kovan-optimistic.etherscan.io](https://kovan-optimistic.etherscan.io)
+- [polygonscan.com](https://polygonscan.com)
+- [testnet.polygonscan.com](https://testnet.polygonscan.com)
+- [arbiscan.io](https://arbiscan.io)
+- [testnet.arbiscan.io](https://testnet.arbiscan.io)
+- [snowtrace.io](https://snowtrace.io)
+- [testnet.snowtrace.io](https://testnet.snowtrace.io)

--- a/packages/bookmarklet/bookmarklet.test.ts
+++ b/packages/bookmarklet/bookmarklet.test.ts
@@ -1,0 +1,51 @@
+import { expect } from "earljs";
+
+import { explorerApiUrls } from "../ethereum-viewer/src/explorer/networks";
+import { apiUrlToWebsite } from "../ethereum-viewer/src/explorer/apiUrlToWebsite";
+import { ethViewerCommands } from "../vscode-host/src/deth/commands/ethViewerCommands";
+import { givenUrl } from "../vscode-host/src/test/test-utils";
+import { toDethNet } from "./bookmarklet";
+
+describe(`bookmarklet: ${toDethNet.name}`, () => {
+  const websiteUrls = Object.values(explorerApiUrls).map(
+    (url) =>
+      apiUrlToWebsite(url) +
+      "/address/0x0000000000000000000000000000000000000000"
+  );
+
+  it("returns hostname ending with deth.net", () => {
+    const urls = websiteUrls.map(toDethNet);
+    for (const actual of urls) {
+      expect(actual).toEqual(expect.stringMatching(/\.deth\.net\//));
+    }
+  });
+
+  it("preserves contract address", () => {
+    const urls = websiteUrls.map(toDethNet);
+    for (const actual of urls) {
+      expect(actual).toEqual(expect.stringMatching(/address\/0x[0-9a-f]{40}/));
+    }
+
+    const address = `0x${Math.floor(
+      Math.random() * 10 ** Math.floor(Math.log10(Number.MAX_SAFE_INTEGER))
+    )}`.padEnd(42, "0");
+
+    expect(toDethNet(`https://etherscan.io/address/${address}`)).toEqual(
+      `https://etherscan.deth.net/address/${address}`
+    );
+  });
+
+  it("preserves explorer api name for all explorers", () => {
+    for (const apiName of Object.keys(explorerApiUrls)) {
+      const websiteUrl =
+        apiUrlToWebsite(
+          explorerApiUrls[apiName as keyof typeof explorerApiUrls]
+        ) + "/address/0x0000000000000000000000000000000000000000";
+
+      const ecvUrl = toDethNet(websiteUrl);
+
+      givenUrl(ecvUrl);
+      expect(ethViewerCommands.getApiName()).toEqual(apiName);
+    }
+  });
+});

--- a/packages/bookmarklet/bookmarklet.ts
+++ b/packages/bookmarklet/bookmarklet.ts
@@ -1,0 +1,9 @@
+/**
+ * How to turn this into a bookmarklet:
+ * - Replace `return href.` in function body with `location.href = location.href.`
+ * - Prefix with `javascript: `
+ * - Paste it into the readme or test it in your browser
+ */
+export function toDethNet(href: string): string {
+  return href.replace(/\.\w+(\/)/, ".deth.net/");
+}

--- a/packages/bookmarklet/tsconfig.json
+++ b/packages/bookmarklet/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "checkJs": true,
+    "noEmit": true,
+    "module": "CommonJS"
+  },
+  "include": [
+    "*.ts",
+    "../ethereum-viewer/src/explorer/**/*.ts",
+    "../vscode-host/src/deth/**/*.ts",
+    "../vscode-host/src/test/**/*.ts"
+  ]
+}

--- a/packages/ethereum-viewer/package.json
+++ b/packages/ethereum-viewer/package.json
@@ -10,7 +10,8 @@
     "watch": "webpack --watch",
     "pretest": "yarn run build",
     "lint": "eslint src --ext ts",
-    "serve": "serve --cors -l 5000 --ssl-cert ../../certs/localhost.pem --ssl-key ../../certs/localhost-key.pem"
+    "serve": "serve --cors -l 5000 --ssl-cert ../../certs/localhost.pem --ssl-key ../../certs/localhost-key.pem",
+    "supported-explorers": "ts-node ./scripts/supported-explorers"
   },
   "dependencies": {
     "fast-json-stable-stringify": "^2.1.0",

--- a/packages/ethereum-viewer/scripts/supported-explorers.ts
+++ b/packages/ethereum-viewer/scripts/supported-explorers.ts
@@ -1,0 +1,18 @@
+import { apiUrlToWebsite } from "../src/explorer/apiUrlToWebsite";
+import { explorerApiUrls } from "../src/explorer/networks";
+
+function printSupportedExplorers() {
+  console.log(
+    "\n" +
+      Object.values(explorerApiUrls)
+        .map((url) => {
+          const websiteUrl = apiUrlToWebsite(url);
+          const label = websiteUrl.replace(/^https?:\/\//, "");
+          return `- [${label}](${websiteUrl})`;
+        })
+        .join("\n") +
+      "\n"
+  );
+}
+
+if (require.main === module) printSupportedExplorers();

--- a/packages/ethereum-viewer/src/contributedCommands.ts
+++ b/packages/ethereum-viewer/src/contributedCommands.ts
@@ -3,6 +3,7 @@ import { commands, ExtensionContext, QuickPickItem, window } from "vscode";
 import { ApiName, explorerApiUrls, networkNames } from "./explorer";
 import { FileSystem } from "./fs";
 import { openContractSource } from "./openContractSource";
+import { renderStatusBarItems } from "./statusBar";
 import { unsafeEntries } from "./util/unsafeEntries";
 
 export function registerContributedCommands(
@@ -49,7 +50,13 @@ export function registerContributedCommands(
 
       const { apiName } = picked;
 
-      await openContractSource(context, { fs, address, apiName });
+      const info = await openContractSource(context, { fs, address, apiName });
+
+      renderStatusBarItems({
+        contractAddress: address,
+        contractName: info.ContractName || "contract",
+        apiName,
+      });
     },
   };
 

--- a/packages/ethereum-viewer/src/explorer/apiUrlToWebsite.ts
+++ b/packages/ethereum-viewer/src/explorer/apiUrlToWebsite.ts
@@ -1,0 +1,7 @@
+export function apiUrlToWebsite(url: string) {
+  // This is a bit of a hack, but they all have the same URL scheme.
+  return url
+    .replace("//api.", "//")
+    .replace("//api-", "//")
+    .replace(/\/api$/, "");
+}

--- a/packages/ethereum-viewer/src/explorer/fetchFiles.ts
+++ b/packages/ethereum-viewer/src/explorer/fetchFiles.ts
@@ -4,6 +4,7 @@ import { assert, StrictOmit } from "ts-essentials";
 import { fetch as _fetch } from "../util/fetch";
 import { prettyStringify } from "../util/stringify";
 import * as types from "./api-types";
+import { apiUrlToWebsite } from "./apiUrlToWebsite";
 import { fileExtension } from "./fileExtension";
 import { ApiName, explorerApiKeys, explorerApiUrls } from "./networks";
 
@@ -118,7 +119,11 @@ function prefixFiles(files: FileContents, prefix: string): FileContents {
 
 export interface FetchFilesResult {
   files: FileContents;
-  info: ContractInfo & { implementation?: ContractInfo };
+  info: ContractInfoWithImplementation;
+}
+
+export interface ContractInfoWithImplementation extends ContractInfo {
+  implementation?: ContractInfo;
 }
 
 export interface ContractInfo
@@ -140,12 +145,4 @@ Oops! It seems this contract source code is not verified on ${websiteUrl}.
 
 Take a look at ${websiteUrl}/address/${contractAddress}.
 `;
-}
-
-function apiUrlToWebsite(url: string) {
-  // This is a bit of a hack, but they all have the same URL scheme.
-  return url
-    .replace("//api.", "//")
-    .replace("//api-", "//")
-    .replace(/\/api$/, "");
 }

--- a/packages/ethereum-viewer/src/extension.ts
+++ b/packages/ethereum-viewer/src/extension.ts
@@ -6,6 +6,7 @@ import * as explorer from "./explorer";
 import { explorerApiUrls, networkNames } from "./explorer";
 import { FileSystem } from "./fs";
 import { openContractSource } from "./openContractSource";
+import { renderStatusBarItems } from "./statusBar";
 
 let initialized = false;
 const fs = FileSystem();
@@ -42,7 +43,23 @@ async function main(context: vscode.ExtensionContext) {
     return;
   }
 
-  await openContractSource(context, { fs, apiName, address });
+  renderStatusBarItems({
+    contractAddress: address,
+    contractName: "contract",
+    apiName,
+  });
+
+  const info = await openContractSource(context, {
+    fs,
+    apiName,
+    address,
+  });
+
+  renderStatusBarItems({
+    contractAddress: address,
+    contractName: info.ContractName || "contract",
+    apiName,
+  });
 }
 
 async function detectExplorerApiName(): Promise<explorer.ApiName> {

--- a/packages/ethereum-viewer/src/openContractSource.ts
+++ b/packages/ethereum-viewer/src/openContractSource.ts
@@ -49,16 +49,9 @@ export async function openContractSource(
   );
   context.subscriptions.push(textSearchProviderDisposable);
 
-  // We're trying to open the file even if it doesn't exist yet.
   await showTextDocument(mainFile);
-  // Because the following seems to be very slow:
-  // // onFileChangeOnce(
-  // //   context,
-  // //   fs,
-  // //   mainFile,
-  // //   (e) => void showTextDocument(e.uri.path)
-  // // );
-  // It's causing some errors in the console, but in the end it provides better UX.
+
+  return info;
 }
 
 async function saveContractFilesToFs({
@@ -106,6 +99,15 @@ function getMainContractFile(
 }
 
 async function showTextDocument(path: string) {
+  // We're trying to open the file even if it doesn't exist yet.
+  // Because the following seems to be very slow:
+  // // onFileChangeOnce(
+  // //   context,
+  // //   fs,
+  // //   mainFile,
+  // //   (e) => void showTextDocument(e.uri.path)
+  // // );
+  // It's causing some errors in the console, but in the end it provides better UX.
   await window.showTextDocument(
     Uri.from({ scheme: "memfs", path: "/" + path })
   );

--- a/packages/ethereum-viewer/src/statusBar.ts
+++ b/packages/ethereum-viewer/src/statusBar.ts
@@ -1,0 +1,65 @@
+import { StatusBarAlignment, StatusBarItem, Uri, window } from "vscode";
+
+import { apiUrlToWebsite } from "./explorer/apiUrlToWebsite";
+import { ApiName, explorerApiUrls } from "./explorer/networks";
+
+export function renderStatusBarItems(
+  args:
+    | {
+        contractAddress: string;
+        contractName: string;
+        apiName: ApiName;
+      }
+    | {}
+) {
+  if ("contractAddress" in args) {
+    const { apiName, contractAddress, contractName } = args;
+    const website = apiUrlToWebsite(explorerApiUrls[apiName]);
+    const link = `${website}/address/${contractAddress}`;
+
+    const where = apiName.endsWith("etherscan")
+      ? "on Etherscan"
+      : "in the explorer";
+
+    const tooltip = `Open ${link}`;
+    renderStatusBarItem({
+      key: "ethereum-viewer.etherscan-link",
+      text: `$(eye) See ${contractName} ${where} (${contractAddress})`,
+      tooltip,
+      command: {
+        title: "Open on Etherscan",
+        command: "vscode.open",
+        arguments: [Uri.parse(link)],
+      },
+      priority: 0,
+    });
+  }
+}
+
+const _renderedItems = new Map<string, StatusBarItem>();
+
+interface RenderStatusBarItemArgs
+  extends Pick<StatusBarItem, "text" | "tooltip" | "command">,
+    Pick<window.StatusBarItemOptions, "alignment" | "priority"> {
+  priority?: number;
+  key: string;
+}
+
+function renderStatusBarItem(args: RenderStatusBarItemArgs) {
+  let item = _renderedItems.get(args.key)!;
+
+  item ||= window.createStatusBarItem(
+    args.alignment || StatusBarAlignment.Left,
+    args.priority
+  );
+
+  item.tooltip = args.tooltip;
+  item.text = args.text;
+  item.command = args.command;
+
+  item.show();
+
+  _renderedItems.set(args.key, item);
+
+  return item;
+}

--- a/packages/ethereum-viewer/webpack.config.ts
+++ b/packages/ethereum-viewer/webpack.config.ts
@@ -51,7 +51,7 @@ const webExtensionConfig: webpack.Configuration = {
   performance: {
     hints: false,
   },
-  devtool: "nosources-source-map",
+  devtool: "eval-cheap-module-source-map",
   infrastructureLogging: {
     level: "log",
   },

--- a/packages/vscode-host/src/code/browser/workbench/workbench.ts
+++ b/packages/vscode-host/src/code/browser/workbench/workbench.ts
@@ -53,9 +53,9 @@ async function main() {
     config = { ...config, workspaceProvider };
   }
 
-  const contractAddress = ethViewerCommands.getContractAddress();
-
   setTimeout(() => renderNotification(), 500);
+
+  const apiName = ethViewerCommands.getApiName() || "etherscan";
 
   create(document.body, {
     ...config,
@@ -65,10 +65,7 @@ async function main() {
     },
     windowIndicator: {
       onDidChange: Event.None,
-      label: localize(
-        "playgroundLabel",
-        `$(remote) deth.net` + (contractAddress ? `: ${contractAddress}` : "")
-      ),
+      label: localize("playgroundLabel", `$(remote) ${apiName}.deth.net`),
       tooltip: localize(
         "playgroundTooltip",
         "See Ethereum Code Viewer on GitHub"


### PR DESCRIPTION
### What's changed?

- Added a bookmarklet, admittedly very aggressive one, but I decided it's better to have something very simple and easy to trust than an overengineered monstrosity.
  - There are tests for it. I wrote it directly in the readme initially and it obviously didn't work :P
- Added a list of supported Etherscan instances to _docs/supported-explorers.md_ and a script to generate them to _ethereum-viewer_ package.

---

Depends on https://github.com/dethcrypto/ethereum-code-viewer/pull/34 to avoid conflicts.

Closes #33.